### PR TITLE
Fix issue 9.

### DIFF
--- a/TextBladev2.ahk
+++ b/TextBladev2.ahk
@@ -34,6 +34,7 @@ if not(xls)
 
 
 ; Load hotkeys.
+Critical 10000
 For Key in xls.Worksheets(TB_LayoutSheet).Range(TB_LayoutTable . "[Hotkey]")
 {
   value := Key.Value2


### PR DESCRIPTION
Add "critical" to startup to stop firing of hotkeys until load completed.
